### PR TITLE
build: always update 'latest' release/tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,10 @@ jobs:
                   artifacts: "./module.json,./ponyfinder-foundryvtt-module.zip"
                   tag: v${{ fromJson(steps.get_version.outputs.moduleJson).version }}
                   token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Update Latest
+              uses: ncipollo/release-action@v1
+              with:
+                  allowUpdates: true
+                  artifacts: "./module.json,./ponyfinder-foundryvtt-module.zip"
+                  tag: latest
+                  token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes an oversight of mine, so it will update 'latest' along with the given version number.