### PR TITLE
Use script for heritages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,4 @@
+{
+    "ponyfinder-foundryvtt-module.enableHeritageAbilityBoosts": "Enable Heritage Ability Boosts:",
+    "ponyfinder-foundryvtt-module.enableHeritageAbilityBoostsHint": "When enabled, if an ancestry or heritage is added to an actor and that actor's heritage contains ability boost data, those ability boosts will be copied to the actor's ancestry (overriding the ancestry's ability boosts). This is needed to make the heritage-based ability boosts found in Ponyfinder content work."
+}

--- a/module.json
+++ b/module.json
@@ -9,6 +9,14 @@
     "url": "https://github.com/MemelyPepeartly/ponyfinder-foundryvtt-module",
     "download": "https://github.com/MemelyPepeartly/ponyfinder-foundryvtt-module/releases/download/latest/ponyfinder-foundryvtt-module.zip",
     "manifest": "https://github.com/MemelyPepeartly/ponyfinder-foundryvtt-module/releases/download/latest/module.json",
+    "esmodules": ["./dist/scripts/heritage-ability-boosts.mjs"],
+    "languages": [
+        {
+            "lang": "en",
+            "name": "English",
+            "path": "./lang/en.json"
+        }
+    ],
     "packs": [
         {
             "name": "ponyfinder-actions",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "husky-v4": "^4.3.8",
                 "lint-staged": "^13.0.1",
                 "npm-run-all": "^4.1.5",
+                "patch-package": "^6.4.7",
                 "prettier": "^2.6.2",
                 "typescript": "^4.7.4"
             },
@@ -2310,6 +2311,12 @@
             "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
             "dev": true
         },
+        "node_modules/@yarnpkg/lockfile": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+            "dev": true
+        },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -2791,6 +2798,35 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/find-yarn-workspace-root": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+            "dev": true,
+            "dependencies": {
+                "micromatch": "^4.0.2"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2864,6 +2900,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/graceful-fs": {
@@ -3037,6 +3093,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
         "node_modules/internal-slot": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -3097,6 +3169,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "dependencies": {
+                "ci-info": "^2.0.0"
+            },
+            "bin": {
+                "is-ci": "bin.js"
+            }
+        },
         "node_modules/is-core-module": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -3122,6 +3206,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-fullwidth-code-point": {
@@ -3254,6 +3353,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3283,6 +3394,24 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
+        },
+        "node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/klaw-sync": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.11"
+            }
         },
         "node_modules/lilconfig": {
             "version": "2.0.5",
@@ -3919,6 +4048,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
         "node_modules/onetime": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -3934,6 +4072,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "dependencies": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/opencollective-postinstall": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -3941,6 +4095,15 @@
             "dev": true,
             "bin": {
                 "opencollective-postinstall": "index.js"
+            }
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/p-limit": {
@@ -4039,6 +4202,162 @@
             "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
             "dev": true
         },
+        "node_modules/patch-package": {
+            "version": "6.4.7",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+            "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+            "dev": true,
+            "dependencies": {
+                "@yarnpkg/lockfile": "^1.1.0",
+                "chalk": "^2.4.2",
+                "cross-spawn": "^6.0.5",
+                "find-yarn-workspace-root": "^2.0.0",
+                "fs-extra": "^7.0.1",
+                "is-ci": "^2.0.0",
+                "klaw-sync": "^6.0.0",
+                "minimist": "^1.2.0",
+                "open": "^7.4.2",
+                "rimraf": "^2.6.3",
+                "semver": "^5.6.0",
+                "slash": "^2.0.0",
+                "tmp": "^0.0.33"
+            },
+            "bin": {
+                "patch-package": "index.js"
+            },
+            "engines": {
+                "npm": ">5"
+            }
+        },
+        "node_modules/patch-package/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/patch-package/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/patch-package/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/patch-package/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/patch-package/node_modules/cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "dependencies": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            },
+            "engines": {
+                "node": ">=4.8"
+            }
+        },
+        "node_modules/patch-package/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/patch-package/node_modules/path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/patch-package/node_modules/shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/patch-package/node_modules/shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/patch-package/node_modules/slash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/patch-package/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/patch-package/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4046,6 +4365,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
@@ -4440,6 +4768,18 @@
             "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
             "dev": true
         },
+        "node_modules/rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            }
+        },
         "node_modules/rxjs": {
             "version": "7.5.5",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
@@ -4774,6 +5114,18 @@
             "integrity": "sha512-aIsFTYiuESpoYkCgkoojpVtPwrSvYBxp4mMEGsj20CnUruLCWosywkbYHDII+j7KlQZZn3p+xK89f5gT3QyuGw==",
             "dev": true
         },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4843,6 +5195,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
         "node_modules/url": {
@@ -4977,6 +5338,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
         },
         "node_modules/ws": {
             "version": "8.2.3",
@@ -7225,6 +7592,12 @@
             "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
             "dev": true
         },
+        "@yarnpkg/lockfile": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+            "dev": true
+        },
         "aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -7590,6 +7963,32 @@
                 "semver-regex": "^3.1.2"
             }
         },
+        "find-yarn-workspace-root": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+            "dev": true,
+            "requires": {
+                "micromatch": "^4.0.2"
+            }
+        },
+        "fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7639,6 +8038,20 @@
             "requires": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.1"
+            }
+        },
+        "glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -7757,6 +8170,22 @@
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true
         },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
         "internal-slot": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -7799,6 +8228,15 @@
             "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
             "dev": true
         },
+        "is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "requires": {
+                "ci-info": "^2.0.0"
+            }
+        },
         "is-core-module": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -7816,6 +8254,12 @@
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
+        },
+        "is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true
         },
         "is-fullwidth-code-point": {
             "version": "4.0.0",
@@ -7896,6 +8340,15 @@
                 "call-bind": "^1.0.2"
             }
         },
+        "is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "requires": {
+                "is-docker": "^2.0.0"
+            }
+        },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7925,6 +8378,24 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "klaw-sync": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11"
+            }
         },
         "lilconfig": {
             "version": "2.0.5",
@@ -8401,6 +8872,15 @@
                 "object-keys": "^1.1.1"
             }
         },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
         "onetime": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -8410,10 +8890,26 @@
                 "mimic-fn": "^4.0.0"
             }
         },
+        "open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "requires": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            }
+        },
         "opencollective-postinstall": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
             "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
             "dev": true
         },
         "p-limit": {
@@ -8482,10 +8978,138 @@
             "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
             "dev": true
         },
+        "patch-package": {
+            "version": "6.4.7",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+            "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+            "dev": true,
+            "requires": {
+                "@yarnpkg/lockfile": "^1.1.0",
+                "chalk": "^2.4.2",
+                "cross-spawn": "^6.0.5",
+                "find-yarn-workspace-root": "^2.0.0",
+                "fs-extra": "^7.0.1",
+                "is-ci": "^2.0.0",
+                "klaw-sync": "^6.0.0",
+                "minimist": "^1.2.0",
+                "open": "^7.4.2",
+                "rimraf": "^2.6.3",
+                "semver": "^5.6.0",
+                "slash": "^2.0.0",
+                "tmp": "^0.0.33"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true
         },
         "path-key": {
@@ -8806,6 +9430,15 @@
             "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
             "dev": true
         },
+        "rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
         "rxjs": {
             "version": "7.5.5",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
@@ -9055,6 +9688,15 @@
             "integrity": "sha512-aIsFTYiuESpoYkCgkoojpVtPwrSvYBxp4mMEGsj20CnUruLCWosywkbYHDII+j7KlQZZn3p+xK89f5gT3QyuGw==",
             "dev": true
         },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
         "to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9100,6 +9742,12 @@
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
             }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
         },
         "url": {
             "version": "0.11.0",
@@ -9205,6 +9853,12 @@
                     }
                 }
             }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
         },
         "ws": {
             "version": "8.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,13 @@
         "": {
             "name": "ponyfinder-foundryvtt-module",
             "devDependencies": {
+                "@league-of-foundry-developers/foundry-vtt-types": "^9.269.0",
+                "@tsconfig/node16": "^1.0.3",
                 "husky-v4": "^4.3.8",
                 "lint-staged": "^13.0.1",
-                "prettier": "^2.6.2"
+                "npm-run-all": "^4.1.5",
+                "prettier": "^2.6.2",
+                "typescript": "^4.7.4"
             },
             "engines": {
                 "node": "16"
@@ -111,10 +115,2199 @@
                 "node": ">=4"
             }
         },
+        "node_modules/@league-of-foundry-developers/foundry-vtt-types": {
+            "version": "9.269.0",
+            "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.269.0.tgz",
+            "integrity": "sha512-M/rz86decPLXet9e6+bi0dm8WSGrT/5MM1QXUMEC7Z8vfKB9Y5D61B1J5laaqb3DdjVDS1kZtQEW3/sPg3EALw==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/graphics-smooth": "0.0.22",
+                "@types/jquery": "~3.5.9",
+                "@types/simple-peer": "~9.11.1",
+                "handlebars": "4.7.7",
+                "pixi-particles": "4.3.1",
+                "pixi.js": "5.3.11",
+                "socket.io-client": "4.3.2",
+                "tinymce": "5.10.1"
+            }
+        },
+        "node_modules/@pixi/accessibility": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.11.tgz",
+            "integrity": "sha512-/oSizd8/g6KUCeAlknMLJ9CRxBt+vWs6e2DrOctMoRupEHcmhICCjIyAp5GF6RZy9T9gNHDOU5p7vo7qEyVxgQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/accessibility/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/accessibility/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/accessibility/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/accessibility/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/accessibility/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/accessibility/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/accessibility/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/accessibility/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/app": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.11.tgz",
+            "integrity": "sha512-ZWrOjGvVl+lK5OJQT3OqSnSRtU2XgQSe/ULg2uGsSWUqMkJews33JIGOjvk4tIsjm4ekSKiPZRMdYFHzPfgEJg==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/app/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/app/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/app/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/app/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/app/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/app/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/app/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/app/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/constants": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.4.2.tgz",
+            "integrity": "sha512-qj+eviYmJqeGkMbIKSkp1FVMLglQPVyzzyo/2/0VYmSuY4m4WItC4w3wtyjDd4vBK9YxZIUBZz+LKJvKkRplLQ==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@pixi/core": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.4.2.tgz",
+            "integrity": "sha512-W5RWg0537uz2ni0BW9pA0gRmYGBE628e5XR4iDXO5VLSIZmc4jcaBLsPC7o1amcg1xo5Ty44yMpVpodv+GGRCw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/offscreencanvas": "^2019.6.4"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            },
+            "peerDependencies": {
+                "@pixi/constants": "6.4.2",
+                "@pixi/math": "6.4.2",
+                "@pixi/runner": "6.4.2",
+                "@pixi/settings": "6.4.2",
+                "@pixi/ticker": "6.4.2",
+                "@pixi/utils": "6.4.2"
+            }
+        },
+        "node_modules/@pixi/display": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.4.2.tgz",
+            "integrity": "sha512-mE35oRa4Ex5NOVXsuk7JldmmjBfO0gtOO7FPU3VpheOB13HLoacJ4XAa1HfAGapFiFZe+K19gOXEiOj1RyJfGA==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "@pixi/math": "6.4.2",
+                "@pixi/settings": "6.4.2",
+                "@pixi/utils": "6.4.2"
+            }
+        },
+        "node_modules/@pixi/extract": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.11.tgz",
+            "integrity": "sha512-YeBrpIO3E5HUgcdKEldCUqwwDNHm5OBe98YFcdLr5Z0+dQaHnxp9Dm4n75/NojoGb5guYdrV00x+gU2UPHsVdw==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/extract/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/extract/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/extract/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/extract/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/extract/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/extract/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/extract/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/filter-alpha": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.11.tgz",
+            "integrity": "sha512-HC4PbiEqDWSi3A715av7knFqD3knSXRxPJKG9mWat2CU9eCizSw+JxXp/okMU/fL4ewooiqQWVU2l1wXOHhVFw==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-alpha/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-alpha/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/filter-alpha/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-alpha/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-alpha/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/filter-alpha/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-alpha/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/filter-blur": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.11.tgz",
+            "integrity": "sha512-iW5cOMEcDiJidOV95bUfhxdcvwM9JzCoWAd+92gAie8L+ElRSHpu1jxXbKHjo/QczQV1LulOlheyDaJNpaBCDg==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-blur/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-blur/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/filter-blur/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-blur/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-blur/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/filter-blur/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-blur/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/filter-color-matrix": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.11.tgz",
+            "integrity": "sha512-u9NT4+N1I3XV9ygwsmF8/jIwCLqNCLeFOdM4f73kbw/UmakZZ6i6xjjJMc5YFUpC25qDr1TFlqgdGGGHAPl4ug==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-color-matrix/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-color-matrix/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/filter-color-matrix/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-color-matrix/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-color-matrix/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/filter-color-matrix/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-color-matrix/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/filter-displacement": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.11.tgz",
+            "integrity": "sha512-CTIy7C/L9I1X3VNx4nMzQbMFvznsGk2viQh0dSo8r5NLgmaAdxhkGI0KUpNjLBz30278tzFfNuRe59K1y1kHuw==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/math": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-displacement/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-displacement/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/filter-displacement/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-displacement/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-displacement/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/filter-displacement/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-displacement/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/filter-fxaa": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.11.tgz",
+            "integrity": "sha512-0ahjui5385e1vRvd7zCc0n5W8ULtNI1uVbDJHP9ueeiF25TKC0GqtZzntNwrQPoU46q8zXdnIGjzMpikbbAasg==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-fxaa/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-fxaa/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/filter-fxaa/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-fxaa/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-fxaa/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/filter-fxaa/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-fxaa/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/filter-noise": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.11.tgz",
+            "integrity": "sha512-98WC9Nd5u2F03Ned9T3vnbmO/YF1jLSioZ623z9wjqpd5DosZgRtYTSGxjVcXTSfpviIuiJpkyF+X097pbVprg==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-noise/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-noise/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/filter-noise/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-noise/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/filter-noise/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/filter-noise/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/filter-noise/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/graphics": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.4.2.tgz",
+            "integrity": "sha512-bMIuOee3ONsibRzq9/YUOPfrJ9rD5UK4ifhHRcB5sXwyRXhVK2HNkT2H4+0JQ8o7TxqjJE8neb5en9hn3ZR3SQ==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "@pixi/constants": "6.4.2",
+                "@pixi/core": "6.4.2",
+                "@pixi/display": "6.4.2",
+                "@pixi/math": "6.4.2",
+                "@pixi/sprite": "6.4.2",
+                "@pixi/utils": "6.4.2"
+            }
+        },
+        "node_modules/@pixi/graphics-smooth": {
+            "version": "0.0.22",
+            "resolved": "https://registry.npmjs.org/@pixi/graphics-smooth/-/graphics-smooth-0.0.22.tgz",
+            "integrity": "sha512-qq2u+BJBIDBuuSTc2Xzm1D/8RiiKBdxnVDiMb7Go5v8achnV5ctC6m+rf8Mq0sWm66mbOqu1aq/9efT4A4sPrA==",
+            "dev": true,
+            "engines": {
+                "node": ">=14",
+                "npm": ">=7"
+            },
+            "peerDependencies": {
+                "@pixi/constants": "^6.0.4",
+                "@pixi/core": "^6.0.4",
+                "@pixi/display": "^6.0.4",
+                "@pixi/graphics": "^6.0.4",
+                "@pixi/math": "^6.0.4",
+                "@pixi/utils": "^6.0.4"
+            }
+        },
+        "node_modules/@pixi/interaction": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.11.tgz",
+            "integrity": "sha512-n2K99CYyBcrf8NPxpzmZ5IlJ9TEplsSZfJ/uzMNOEnTObKl4wAhxs51Nb58raH3Ouzwu14YHOpqYrBTEoT1yPA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/interaction/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/interaction/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/interaction/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/interaction/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/interaction/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/interaction/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/interaction/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/interaction/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/loaders": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.11.tgz",
+            "integrity": "sha512-1HAeb/NFXyhNhZWAbVkngsTPBGpjZEPhQflBTrKycRaub7XDSZ8F0fwPltpKKVRWNDT+HBgU/zDNE2fpjzqfYg==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/utils": "5.3.11",
+                "resource-loader": "^3.0.1"
+            }
+        },
+        "node_modules/@pixi/loaders/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/loaders/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/loaders/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/loaders/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/loaders/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/loaders/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/loaders/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/math": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.4.2.tgz",
+            "integrity": "sha512-/byuwLhzln7Gahl3pT/Ckfwe4nvAQ3tAYu+38B+b18HkQWi3Ykci/QwVq/nICb5sa5tJzW3icno2qcv7zBd2xQ==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@pixi/mesh": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.11.tgz",
+            "integrity": "sha512-KWKKksEr0YuUX1uz1FmpIa/Y37b/0pvFUS+87LoyYq0mRtGbKsTY5i3lBPG/taHwN7a2DQAX3JZpw6yhGKoGpA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mesh-extras": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.11.tgz",
+            "integrity": "sha512-1GTCMMUW1xv/72x26cxRysblBXW0wU77TNgqtSIMZ1M6JbleObChklWTvwi9MzQO2vQ3S6Hvcsa5m5EiM2hSPQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/mesh": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mesh-extras/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/mesh-extras/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/mesh-extras/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/mesh-extras/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/mesh-extras/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/mesh-extras/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mesh-extras/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/mesh/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/mesh/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/mesh/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mesh/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/mesh/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/mesh/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/mesh/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mesh/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.11.tgz",
+            "integrity": "sha512-uQUxatGTTD5zfQ0pWdjibVjT+xEEZJ/xZDZtm/GxC7HSHd4jgoJBcTXWVhbhzwpLPVTnD8+sMnRrGlhoKcpTpQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/sprite": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+            "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mixin-cache-as-bitmap/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/mixin-get-child-by-name": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.11.tgz",
+            "integrity": "sha512-fWFVxWtMYcwJttrgDNmZ4CJrx316p8ToNliC2ILmJZW77me7I4GzJ57gSHQU1xFwdHoOYRC4fnlrZoK5qJ9lDw==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/display": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mixin-get-child-by-name/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/mixin-get-child-by-name/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mixin-get-child-by-name/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/mixin-get-child-by-name/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/mixin-get-child-by-name/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/mixin-get-global-position": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.11.tgz",
+            "integrity": "sha512-wrS9i+UUodLM5XL2N0Y+XSKiqLRdJV3ltFUWG6+jPT5yoP0HsKtx3sFAzX526RwIYwRzRusbc/quxHfRA4tvgg==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mixin-get-global-position/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/mixin-get-global-position/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/mixin-get-global-position/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/mixin-get-global-position/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/mixin-get-global-position/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/particles": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.11.tgz",
+            "integrity": "sha512-+mkt/inWXtRrxQc07RZ29uNIDWV1oMsrRBVBIvHgpR92Kn8EjIDRgoSXNu0jiZ18gRKKCBhwsS4dCXGsZRQ/sA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/particles/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/particles/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/particles/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/particles/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/particles/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/particles/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/particles/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/particles/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/polyfill": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.11.tgz",
+            "integrity": "sha512-yQOngcnn+2/L7n6L/g45hCnIDLWdnWmmcCY3UKJrOgbNX+JtLru1RR8AGLifkdsa0R5u48x584YQGqkTAChWVA==",
+            "dev": true,
+            "dependencies": {
+                "es6-promise-polyfill": "^1.2.0",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "node_modules/@pixi/prepare": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.11.tgz",
+            "integrity": "sha512-TvjGeg7xPKjv5NxbM5NXReno9yxUCw/N0HtDEtEFRVeBLN3u0Q/dZsXxL6gIvkHoS09NFW+7AwsYQLZrVbppjA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/graphics": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/text": "5.3.11",
+                "@pixi/ticker": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/graphics": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.11.tgz",
+            "integrity": "sha512-HLu53LV6mRlY0uFSIM2OrCuL7xqXzeJs5d2QfmUJfKJVVZ9sbHDS+6/N/f0tXzvkRPYhSKXvcNPsNn4HmlIE9w==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/sprite": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+            "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/prepare/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/runner": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.4.2.tgz",
+            "integrity": "sha512-mH1//C931Rd+RB/c66t8VMNmLUGBCnefRftgijV5mBFXNgyP8Dnbig1790Qw4IDKPgiiR1mRmGDGAJAr0Xa/3A==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@pixi/settings": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.4.2.tgz",
+            "integrity": "sha512-wA2PEVoHYaRiQ0/zvq8nqJZkzDT3qLRl8S7yVfL1yhsbCsh6KI0hjCwqy8b8xCAVAMwkInzWx64lvQbfActnAg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/sprite": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.4.2.tgz",
+            "integrity": "sha512-UW3587gBSdY8iCh/t7+7j1CV9iouAQrLvRNw42gJm5iQm+GaLWpQEI3GSaQX9u47fi1C2nokeGa6uB2Hwz/48Q==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "@pixi/constants": "6.4.2",
+                "@pixi/core": "6.4.2",
+                "@pixi/display": "6.4.2",
+                "@pixi/math": "6.4.2",
+                "@pixi/settings": "6.4.2",
+                "@pixi/utils": "6.4.2"
+            }
+        },
+        "node_modules/@pixi/sprite-animated": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.11.tgz",
+            "integrity": "sha512-xU1b6H8nJ1l05h7cBGw2DGo4QdLj7xootstZUx2BrTVX5ZENn5mjAGVD0uRpk8yt7Q6Bj7M+PS7ktzAgBW/hmQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/ticker": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/sprite": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+            "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/sprite-animated/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/sprite-tiling": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.11.tgz",
+            "integrity": "sha512-KUiWsIumjrnp9QKGMe1BqtrV9Hxm91KoaiOlCBk/gw8753iKvuMmH+/Z0RnzeZylJ1sJsdonTWy/IaLi1jnd0g==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/sprite": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+            "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/sprite-tiling/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/spritesheet": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.11.tgz",
+            "integrity": "sha512-Y9Wiwcz/YOuS1v73Ij9KWQakYBzZfldEy3H8T4GPLK+S19/sypntdkNtRZbmR2wWfhJ4axYEB2/Df86aOAU2qA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/loaders": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/spritesheet/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/spritesheet/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/spritesheet/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/spritesheet/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/spritesheet/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/spritesheet/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/spritesheet/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/text": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.11.tgz",
+            "integrity": "sha512-PmWvJv0wiKyyz3fahnxM19+m8IbF2vpDKIImqb5472WyxRGzKyVBW90xrADf5202tdKMk4b8hqvpof2XULr5PA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/text-bitmap": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.11.tgz",
+            "integrity": "sha512-Bjc/G4VHaPXc9HJsvyYOm5cNTHdqmX6AgzBAlCfltuMAlnveUgUPuX8D/MJHRRnoVSDHSmCBtnJgTc0y/nIeCw==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/loaders": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/mesh": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/text": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/text-bitmap/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/text-bitmap/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/text-bitmap/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/text-bitmap/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/text-bitmap/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/text-bitmap/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/text-bitmap/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/text-bitmap/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/sprite": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+            "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/@pixi/text/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "node_modules/@pixi/ticker": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.4.2.tgz",
+            "integrity": "sha512-OM2U0qLiU2Z+qami7DRNkBJnx20ElQO/5mJNsoHQRH6k/po0nXlux8jcCXhh5DE9lds4RdUFAwTL4RmLT1clDw==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "@pixi/settings": "6.4.2"
+            }
+        },
+        "node_modules/@pixi/utils": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.4.2.tgz",
+            "integrity": "sha512-FORUzSikNUNceS6sf2NlRcGukmJrnWCQToA6Nqk+tQ7Lvb42vDTVI66ya44O6HYM2J0nL684YeYesWbAZ+UeKg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/earcut": "^2.1.0",
+                "earcut": "^2.2.2",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            },
+            "peerDependencies": {
+                "@pixi/constants": "6.4.2",
+                "@pixi/settings": "6.4.2"
+            }
+        },
+        "node_modules/@socket.io/component-emitter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+            "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "dev": true
+        },
+        "node_modules/@types/earcut": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
+            "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@types/jquery": {
+            "version": "3.5.14",
+            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+            "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+            "dev": true,
+            "dependencies": {
+                "@types/sizzle": "*"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+            "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+            "dev": true
+        },
+        "node_modules/@types/offscreencanvas": {
+            "version": "2019.7.0",
+            "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+            "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+            "dev": true
+        },
+        "node_modules/@types/simple-peer": {
+            "version": "9.11.4",
+            "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.4.tgz",
+            "integrity": "sha512-Elje14YvM47k+XEaoyRAeUSvZN7TOLWYL233QCckUaXjT4lRESHnYs0iOK2JoosO5DnCvWu/0Vpl9qnw4KCLWw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/sizzle": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+            "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
             "dev": true
         },
         "node_modules/aggregate-error": {
@@ -181,6 +2374,28 @@
                 "node": ">=8"
             }
         },
+        "node_modules/backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
+            "dev": true
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/braces": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -191,6 +2406,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dev": true,
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsites": {
@@ -300,6 +2528,12 @@
             "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
             "dev": true
         },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
+        },
         "node_modules/cosmiconfig": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -347,6 +2581,28 @@
                 }
             }
         },
+        "node_modules/define-properties": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+            "dev": true,
+            "dependencies": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/earcut": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+            "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug==",
+            "dev": true
+        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -359,6 +2615,32 @@
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true
         },
+        "node_modules/engine.io-client": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.0.3.tgz",
+            "integrity": "sha512-IH8ZhDIwiLv0d/wXVzmjfV9Y82hbJIDhCGSVUV8o1kcpDe2I6Y3bZA3ZbJy4Ls7k7IVmcy/qn4k9RKWFhUGf5w==",
+            "dev": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.0.0",
+                "debug": "~4.3.1",
+                "engine.io-parser": "~5.0.0",
+                "has-cors": "1.1.0",
+                "parseqs": "0.0.6",
+                "parseuri": "0.0.6",
+                "ws": "~8.2.3",
+                "xmlhttprequest-ssl": "~2.0.0",
+                "yeast": "0.1.2"
+            }
+        },
+        "node_modules/engine.io-parser": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+            "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -368,6 +2650,66 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/es-abstract": {
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+            "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "function.prototype.name": "^1.1.5",
+                "get-intrinsic": "^1.1.1",
+                "get-symbol-description": "^1.0.0",
+                "has": "^1.0.3",
+                "has-property-descriptors": "^1.0.0",
+                "has-symbols": "^1.0.3",
+                "internal-slot": "^1.0.3",
+                "is-callable": "^1.2.4",
+                "is-negative-zero": "^2.0.2",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "is-string": "^1.0.7",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.12.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "regexp.prototype.flags": "^1.4.3",
+                "string.prototype.trimend": "^1.0.5",
+                "string.prototype.trimstart": "^1.0.5",
+                "unbox-primitive": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
+            "dependencies": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es6-promise-polyfill": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
+            "integrity": "sha512-HHb0vydCpoclpd0ySPkRXMmBw80MRt1wM4RBJBlXkux97K7gleabZdsR0gvE1nNPM9mgOZIBTzjjXiPxf4lIqQ==",
+            "dev": true
+        },
         "node_modules/escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -376,6 +2718,12 @@
             "engines": {
                 "node": ">=0.8.0"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+            "dev": true
         },
         "node_modules/execa": {
             "version": "6.1.0",
@@ -443,6 +2791,53 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "node_modules/function.prototype.name": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+            "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.19.0",
+                "functions-have-names": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+            "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+            "dev": true,
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/get-stream": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -455,6 +2850,76 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/get-symbol-description": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.7",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
+        },
+        "node_modules/has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "dependencies": {
+                "function-bind": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/has-bigints": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-cors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+            "integrity": "sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==",
+            "dev": true
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -463,6 +2928,51 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true
         },
         "node_modules/human-signals": {
             "version": "3.0.1",
@@ -527,11 +3037,92 @@
                 "node": ">=8"
             }
         },
+        "node_modules/internal-slot": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.1.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
+        },
+        "node_modules/is-bigint": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+            "dev": true,
+            "dependencies": {
+                "has-bigints": "^1.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-boolean-object": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+            "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+            "dev": true,
+            "dependencies": {
+                "has": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dev": true,
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "4.0.0",
@@ -545,6 +3136,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -552,6 +3155,49 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-number-object": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+            "dev": true,
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-shared-array-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-stream": {
@@ -566,16 +3212,70 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-string": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "dev": true,
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dev": true,
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakref": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
+        "node_modules/ismobilejs": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+            "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+            "dev": true
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "node_modules/json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
@@ -745,6 +3445,34 @@
                 "node": ">=8"
             }
         },
+        "node_modules/load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/load-json-file/node_modules/parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+            "dev": true,
+            "dependencies": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -859,6 +3587,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/memorystream": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+            "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -890,11 +3627,59 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/mini-signals": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
+            "integrity": "sha512-alffqMkGCjjTSwvYMVLx+7QeJ6sTuxbXqBkP21my4iWU5+QpTQAJt3h7htA1OKm9F3BpMM0vnu72QIoiJakrLA==",
+            "dev": true
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
+        },
+        "node_modules/nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
+        "node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -903,6 +3688,163 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm-run-all": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+            "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "memorystream": "^0.3.1",
+                "minimatch": "^3.0.4",
+                "pidtree": "^0.3.0",
+                "read-pkg": "^3.0.0",
+                "shell-quote": "^1.6.1",
+                "string.prototype.padend": "^3.0.0"
+            },
+            "bin": {
+                "npm-run-all": "bin/npm-run-all/index.js",
+                "run-p": "bin/run-p/index.js",
+                "run-s": "bin/run-s/index.js"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/npm-run-all/node_modules/cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "dependencies": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            },
+            "engines": {
+                "node": ">=4.8"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/pidtree": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+            "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+            "dev": true,
+            "bin": {
+                "pidtree": "bin/pidtree.js"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm-run-all/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
             }
         },
         "node_modules/npm-run-path": {
@@ -932,11 +3874,47 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.12.2",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
             "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
             "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -1040,6 +4018,27 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse-uri": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.7.tgz",
+            "integrity": "sha512-eWuZCMKNlVkXrEoANdXxbmqhu2SQO9jUMCSpdbJDObin0JxISn6e400EWsSRbr/czdKvWKkhZnMKEGUwf/Plmg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/parseqs": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+            "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+            "dev": true
+        },
+        "node_modules/parseuri": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+            "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+            "dev": true
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1057,6 +4056,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -1089,6 +4094,176 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pixi-particles": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/pixi-particles/-/pixi-particles-4.3.1.tgz",
+            "integrity": "sha512-XSqDFgYwm/7FRCgP5I2Fc57d98qvb1ql/x4uTjdP4uXDUGgjdO8OW/2A0HVWS1CkOht/1x6dQzsM1oCJAUlaow==",
+            "dev": true,
+            "peerDependencies": {
+                "pixi.js": ">=4.0.0"
+            }
+        },
+        "node_modules/pixi.js": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.11.tgz",
+            "integrity": "sha512-/9td6IHDQqG0Po5lyQ5aKDzrnEVD1SvGourI4Nqp0mvNI0Cbm74tMHLjk1V5foqGPAS9pochENr6Y3ft/2cDiQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/accessibility": "5.3.11",
+                "@pixi/app": "5.3.11",
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/extract": "5.3.11",
+                "@pixi/filter-alpha": "5.3.11",
+                "@pixi/filter-blur": "5.3.11",
+                "@pixi/filter-color-matrix": "5.3.11",
+                "@pixi/filter-displacement": "5.3.11",
+                "@pixi/filter-fxaa": "5.3.11",
+                "@pixi/filter-noise": "5.3.11",
+                "@pixi/graphics": "5.3.11",
+                "@pixi/interaction": "5.3.11",
+                "@pixi/loaders": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/mesh": "5.3.11",
+                "@pixi/mesh-extras": "5.3.11",
+                "@pixi/mixin-cache-as-bitmap": "5.3.11",
+                "@pixi/mixin-get-child-by-name": "5.3.11",
+                "@pixi/mixin-get-global-position": "5.3.11",
+                "@pixi/particles": "5.3.11",
+                "@pixi/polyfill": "5.3.11",
+                "@pixi/prepare": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/sprite-animated": "5.3.11",
+                "@pixi/sprite-tiling": "5.3.11",
+                "@pixi/spritesheet": "5.3.11",
+                "@pixi/text": "5.3.11",
+                "@pixi/text-bitmap": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/pixi.js/node_modules/@pixi/constants": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+            "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+            "dev": true
+        },
+        "node_modules/pixi.js/node_modules/@pixi/core": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+            "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/pixijs"
+            }
+        },
+        "node_modules/pixi.js/node_modules/@pixi/display": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+            "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/pixi.js/node_modules/@pixi/graphics": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.11.tgz",
+            "integrity": "sha512-HLu53LV6mRlY0uFSIM2OrCuL7xqXzeJs5d2QfmUJfKJVVZ9sbHDS+6/N/f0tXzvkRPYhSKXvcNPsNn4HmlIE9w==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/pixi.js/node_modules/@pixi/math": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+            "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+            "dev": true
+        },
+        "node_modules/pixi.js/node_modules/@pixi/runner": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+            "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+            "dev": true
+        },
+        "node_modules/pixi.js/node_modules/@pixi/settings": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+            "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+            "dev": true,
+            "dependencies": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "node_modules/pixi.js/node_modules/@pixi/sprite": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+            "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            }
+        },
+        "node_modules/pixi.js/node_modules/@pixi/ticker": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+            "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/settings": "5.3.11"
+            }
+        },
+        "node_modules/pixi.js/node_modules/@pixi/utils": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+            "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+            "dev": true,
+            "dependencies": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "earcut": "^2.1.5",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
             }
         },
         "node_modules/pkg-dir": {
@@ -1127,6 +4302,82 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+            "dev": true
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+            "dev": true,
+            "dependencies": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/read-pkg/node_modules/path-type": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "dev": true,
+            "dependencies": {
+                "pify": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/regexp.prototype.flags": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+            "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "functions-have-names": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+            "dev": true,
+            "dependencies": {
+                "is-core-module": "^2.9.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1134,6 +4385,16 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/resource-loader": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
+            "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
+            "dev": true,
+            "dependencies": {
+                "mini-signals": "^1.2.0",
+                "parse-uri": "^1.0.0"
             }
         },
         "node_modules/restore-cursor": {
@@ -1188,6 +4449,15 @@
                 "tslib": "^2.1.0"
             }
         },
+        "node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
         "node_modules/semver-compare": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
@@ -1225,6 +4495,26 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+            "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+            "dev": true
+        },
+        "node_modules/side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/signal-exit": {
@@ -1270,6 +4560,77 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/socket.io-client": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.3.2.tgz",
+            "integrity": "sha512-2B9LqSunN60yV8F7S84CCEEcgbYNfrn7ejIInZtLZ7ppWtiX8rGZAjvdCvbnC8bqo/9RlCNOUsORLyskxSFP1g==",
+            "dev": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.0.0",
+                "backo2": "~1.0.2",
+                "debug": "~4.3.2",
+                "engine.io-client": "~6.0.1",
+                "parseuri": "0.0.6",
+                "socket.io-parser": "~4.1.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/socket.io-parser": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
+            "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
+            "dev": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.0.0",
+                "debug": "~4.3.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "dev": true,
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+            "dev": true
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+            "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+            "dev": true
+        },
         "node_modules/string-argv": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -1296,6 +4657,51 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/string.prototype.padend": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz",
+            "integrity": "sha512-jNIIeokznm8SD/TZISQsZKYu7RJyheFNt84DUPrh482GC8RVp2MKqm2O5oBRdGxbDQoXrhhWtPIWQOiy20svUg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.19.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+            "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.19.5"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimstart": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+            "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.19.5"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
@@ -1309,6 +4715,15 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/strip-final-newline": {
@@ -1335,10 +4750,28 @@
                 "node": ">=8"
             }
         },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "node_modules/tinymce": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.1.tgz",
+            "integrity": "sha512-aIsFTYiuESpoYkCgkoojpVtPwrSvYBxp4mMEGsj20CnUruLCWosywkbYHDII+j7KlQZZn3p+xK89f5gT3QyuGw==",
             "dev": true
         },
         "node_modules/to-regex-range": {
@@ -1371,6 +4804,67 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/typescript": {
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/uglify-js": {
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
+            "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
+            "dev": true,
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/unbox-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.0.3",
+                "which-boxed-primitive": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+            "dev": true,
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1386,6 +4880,22 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dev": true,
+            "dependencies": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/which-pm-runs": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
@@ -1394,6 +4904,12 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -1462,6 +4978,36 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ws": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/xmlhttprequest-ssl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+            "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/yaml": {
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
@@ -1470,6 +5016,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/yeast": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+            "integrity": "sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==",
+            "dev": true
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
@@ -1563,10 +5115,2114 @@
                 }
             }
         },
+        "@league-of-foundry-developers/foundry-vtt-types": {
+            "version": "9.269.0",
+            "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.269.0.tgz",
+            "integrity": "sha512-M/rz86decPLXet9e6+bi0dm8WSGrT/5MM1QXUMEC7Z8vfKB9Y5D61B1J5laaqb3DdjVDS1kZtQEW3/sPg3EALw==",
+            "dev": true,
+            "requires": {
+                "@pixi/graphics-smooth": "0.0.22",
+                "@types/jquery": "~3.5.9",
+                "@types/simple-peer": "~9.11.1",
+                "handlebars": "4.7.7",
+                "pixi-particles": "4.3.1",
+                "pixi.js": "5.3.11",
+                "socket.io-client": "4.3.2",
+                "tinymce": "5.10.1"
+            }
+        },
+        "@pixi/accessibility": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.11.tgz",
+            "integrity": "sha512-/oSizd8/g6KUCeAlknMLJ9CRxBt+vWs6e2DrOctMoRupEHcmhICCjIyAp5GF6RZy9T9gNHDOU5p7vo7qEyVxgQ==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/app": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.11.tgz",
+            "integrity": "sha512-ZWrOjGvVl+lK5OJQT3OqSnSRtU2XgQSe/ULg2uGsSWUqMkJews33JIGOjvk4tIsjm4ekSKiPZRMdYFHzPfgEJg==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/constants": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.4.2.tgz",
+            "integrity": "sha512-qj+eviYmJqeGkMbIKSkp1FVMLglQPVyzzyo/2/0VYmSuY4m4WItC4w3wtyjDd4vBK9YxZIUBZz+LKJvKkRplLQ==",
+            "dev": true,
+            "peer": true
+        },
+        "@pixi/core": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.4.2.tgz",
+            "integrity": "sha512-W5RWg0537uz2ni0BW9pA0gRmYGBE628e5XR4iDXO5VLSIZmc4jcaBLsPC7o1amcg1xo5Ty44yMpVpodv+GGRCw==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/offscreencanvas": "^2019.6.4"
+            }
+        },
+        "@pixi/display": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.4.2.tgz",
+            "integrity": "sha512-mE35oRa4Ex5NOVXsuk7JldmmjBfO0gtOO7FPU3VpheOB13HLoacJ4XAa1HfAGapFiFZe+K19gOXEiOj1RyJfGA==",
+            "dev": true,
+            "peer": true,
+            "requires": {}
+        },
+        "@pixi/extract": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.11.tgz",
+            "integrity": "sha512-YeBrpIO3E5HUgcdKEldCUqwwDNHm5OBe98YFcdLr5Z0+dQaHnxp9Dm4n75/NojoGb5guYdrV00x+gU2UPHsVdw==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/filter-alpha": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.11.tgz",
+            "integrity": "sha512-HC4PbiEqDWSi3A715av7knFqD3knSXRxPJKG9mWat2CU9eCizSw+JxXp/okMU/fL4ewooiqQWVU2l1wXOHhVFw==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/filter-blur": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.11.tgz",
+            "integrity": "sha512-iW5cOMEcDiJidOV95bUfhxdcvwM9JzCoWAd+92gAie8L+ElRSHpu1jxXbKHjo/QczQV1LulOlheyDaJNpaBCDg==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/settings": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/filter-color-matrix": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.11.tgz",
+            "integrity": "sha512-u9NT4+N1I3XV9ygwsmF8/jIwCLqNCLeFOdM4f73kbw/UmakZZ6i6xjjJMc5YFUpC25qDr1TFlqgdGGGHAPl4ug==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/filter-displacement": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.11.tgz",
+            "integrity": "sha512-CTIy7C/L9I1X3VNx4nMzQbMFvznsGk2viQh0dSo8r5NLgmaAdxhkGI0KUpNjLBz30278tzFfNuRe59K1y1kHuw==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/math": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/filter-fxaa": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.11.tgz",
+            "integrity": "sha512-0ahjui5385e1vRvd7zCc0n5W8ULtNI1uVbDJHP9ueeiF25TKC0GqtZzntNwrQPoU46q8zXdnIGjzMpikbbAasg==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/filter-noise": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.11.tgz",
+            "integrity": "sha512-98WC9Nd5u2F03Ned9T3vnbmO/YF1jLSioZ623z9wjqpd5DosZgRtYTSGxjVcXTSfpviIuiJpkyF+X097pbVprg==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/graphics": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.4.2.tgz",
+            "integrity": "sha512-bMIuOee3ONsibRzq9/YUOPfrJ9rD5UK4ifhHRcB5sXwyRXhVK2HNkT2H4+0JQ8o7TxqjJE8neb5en9hn3ZR3SQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {}
+        },
+        "@pixi/graphics-smooth": {
+            "version": "0.0.22",
+            "resolved": "https://registry.npmjs.org/@pixi/graphics-smooth/-/graphics-smooth-0.0.22.tgz",
+            "integrity": "sha512-qq2u+BJBIDBuuSTc2Xzm1D/8RiiKBdxnVDiMb7Go5v8achnV5ctC6m+rf8Mq0sWm66mbOqu1aq/9efT4A4sPrA==",
+            "dev": true,
+            "requires": {}
+        },
+        "@pixi/interaction": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.11.tgz",
+            "integrity": "sha512-n2K99CYyBcrf8NPxpzmZ5IlJ9TEplsSZfJ/uzMNOEnTObKl4wAhxs51Nb58raH3Ouzwu14YHOpqYrBTEoT1yPA==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/loaders": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.11.tgz",
+            "integrity": "sha512-1HAeb/NFXyhNhZWAbVkngsTPBGpjZEPhQflBTrKycRaub7XDSZ8F0fwPltpKKVRWNDT+HBgU/zDNE2fpjzqfYg==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/utils": "5.3.11",
+                "resource-loader": "^3.0.1"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/math": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.4.2.tgz",
+            "integrity": "sha512-/byuwLhzln7Gahl3pT/Ckfwe4nvAQ3tAYu+38B+b18HkQWi3Ykci/QwVq/nICb5sa5tJzW3icno2qcv7zBd2xQ==",
+            "dev": true,
+            "peer": true
+        },
+        "@pixi/mesh": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.11.tgz",
+            "integrity": "sha512-KWKKksEr0YuUX1uz1FmpIa/Y37b/0pvFUS+87LoyYq0mRtGbKsTY5i3lBPG/taHwN7a2DQAX3JZpw6yhGKoGpA==",
+            "dev": true,
+            "requires": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/mesh-extras": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.11.tgz",
+            "integrity": "sha512-1GTCMMUW1xv/72x26cxRysblBXW0wU77TNgqtSIMZ1M6JbleObChklWTvwi9MzQO2vQ3S6Hvcsa5m5EiM2hSPQ==",
+            "dev": true,
+            "requires": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/mesh": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/mixin-cache-as-bitmap": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.11.tgz",
+            "integrity": "sha512-uQUxatGTTD5zfQ0pWdjibVjT+xEEZJ/xZDZtm/GxC7HSHd4jgoJBcTXWVhbhzwpLPVTnD8+sMnRrGlhoKcpTpQ==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/sprite": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+                    "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/core": "5.3.11",
+                        "@pixi/display": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/mixin-get-child-by-name": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.11.tgz",
+            "integrity": "sha512-fWFVxWtMYcwJttrgDNmZ4CJrx316p8ToNliC2ILmJZW77me7I4GzJ57gSHQU1xFwdHoOYRC4fnlrZoK5qJ9lDw==",
+            "dev": true,
+            "requires": {
+                "@pixi/display": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/mixin-get-global-position": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.11.tgz",
+            "integrity": "sha512-wrS9i+UUodLM5XL2N0Y+XSKiqLRdJV3ltFUWG6+jPT5yoP0HsKtx3sFAzX526RwIYwRzRusbc/quxHfRA4tvgg==",
+            "dev": true,
+            "requires": {
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/particles": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.11.tgz",
+            "integrity": "sha512-+mkt/inWXtRrxQc07RZ29uNIDWV1oMsrRBVBIvHgpR92Kn8EjIDRgoSXNu0jiZ18gRKKCBhwsS4dCXGsZRQ/sA==",
+            "dev": true,
+            "requires": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/polyfill": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.11.tgz",
+            "integrity": "sha512-yQOngcnn+2/L7n6L/g45hCnIDLWdnWmmcCY3UKJrOgbNX+JtLru1RR8AGLifkdsa0R5u48x584YQGqkTAChWVA==",
+            "dev": true,
+            "requires": {
+                "es6-promise-polyfill": "^1.2.0",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "@pixi/prepare": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.11.tgz",
+            "integrity": "sha512-TvjGeg7xPKjv5NxbM5NXReno9yxUCw/N0HtDEtEFRVeBLN3u0Q/dZsXxL6gIvkHoS09NFW+7AwsYQLZrVbppjA==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/graphics": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/text": "5.3.11",
+                "@pixi/ticker": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/graphics": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.11.tgz",
+                    "integrity": "sha512-HLu53LV6mRlY0uFSIM2OrCuL7xqXzeJs5d2QfmUJfKJVVZ9sbHDS+6/N/f0tXzvkRPYhSKXvcNPsNn4HmlIE9w==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/core": "5.3.11",
+                        "@pixi/display": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/sprite": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/sprite": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+                    "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/core": "5.3.11",
+                        "@pixi/display": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/runner": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.4.2.tgz",
+            "integrity": "sha512-mH1//C931Rd+RB/c66t8VMNmLUGBCnefRftgijV5mBFXNgyP8Dnbig1790Qw4IDKPgiiR1mRmGDGAJAr0Xa/3A==",
+            "dev": true,
+            "peer": true
+        },
+        "@pixi/settings": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.4.2.tgz",
+            "integrity": "sha512-wA2PEVoHYaRiQ0/zvq8nqJZkzDT3qLRl8S7yVfL1yhsbCsh6KI0hjCwqy8b8xCAVAMwkInzWx64lvQbfActnAg==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "ismobilejs": "^1.1.0"
+            }
+        },
+        "@pixi/sprite": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.4.2.tgz",
+            "integrity": "sha512-UW3587gBSdY8iCh/t7+7j1CV9iouAQrLvRNw42gJm5iQm+GaLWpQEI3GSaQX9u47fi1C2nokeGa6uB2Hwz/48Q==",
+            "dev": true,
+            "peer": true,
+            "requires": {}
+        },
+        "@pixi/sprite-animated": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.11.tgz",
+            "integrity": "sha512-xU1b6H8nJ1l05h7cBGw2DGo4QdLj7xootstZUx2BrTVX5ZENn5mjAGVD0uRpk8yt7Q6Bj7M+PS7ktzAgBW/hmQ==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/ticker": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/sprite": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+                    "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/core": "5.3.11",
+                        "@pixi/display": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/sprite-tiling": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.11.tgz",
+            "integrity": "sha512-KUiWsIumjrnp9QKGMe1BqtrV9Hxm91KoaiOlCBk/gw8753iKvuMmH+/Z0RnzeZylJ1sJsdonTWy/IaLi1jnd0g==",
+            "dev": true,
+            "requires": {
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/sprite": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+                    "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/core": "5.3.11",
+                        "@pixi/display": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/spritesheet": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.11.tgz",
+            "integrity": "sha512-Y9Wiwcz/YOuS1v73Ij9KWQakYBzZfldEy3H8T4GPLK+S19/sypntdkNtRZbmR2wWfhJ4axYEB2/Df86aOAU2qA==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/loaders": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/text": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.11.tgz",
+            "integrity": "sha512-PmWvJv0wiKyyz3fahnxM19+m8IbF2vpDKIImqb5472WyxRGzKyVBW90xrADf5202tdKMk4b8hqvpof2XULr5PA==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/sprite": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+                    "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/core": "5.3.11",
+                        "@pixi/display": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/text-bitmap": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.11.tgz",
+            "integrity": "sha512-Bjc/G4VHaPXc9HJsvyYOm5cNTHdqmX6AgzBAlCfltuMAlnveUgUPuX8D/MJHRRnoVSDHSmCBtnJgTc0y/nIeCw==",
+            "dev": true,
+            "requires": {
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/loaders": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/mesh": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/text": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
+        },
+        "@pixi/ticker": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.4.2.tgz",
+            "integrity": "sha512-OM2U0qLiU2Z+qami7DRNkBJnx20ElQO/5mJNsoHQRH6k/po0nXlux8jcCXhh5DE9lds4RdUFAwTL4RmLT1clDw==",
+            "dev": true,
+            "peer": true,
+            "requires": {}
+        },
+        "@pixi/utils": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.4.2.tgz",
+            "integrity": "sha512-FORUzSikNUNceS6sf2NlRcGukmJrnWCQToA6Nqk+tQ7Lvb42vDTVI66ya44O6HYM2J0nL684YeYesWbAZ+UeKg==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/earcut": "^2.1.0",
+                "earcut": "^2.2.2",
+                "eventemitter3": "^3.1.0",
+                "url": "^0.11.0"
+            }
+        },
+        "@socket.io/component-emitter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+            "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+            "dev": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "dev": true
+        },
+        "@types/earcut": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
+            "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
+            "dev": true,
+            "peer": true
+        },
+        "@types/jquery": {
+            "version": "3.5.14",
+            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+            "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+            "dev": true,
+            "requires": {
+                "@types/sizzle": "*"
+            }
+        },
+        "@types/node": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+            "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+            "dev": true
+        },
+        "@types/offscreencanvas": {
+            "version": "2019.7.0",
+            "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+            "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
+            "dev": true,
+            "peer": true
+        },
         "@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+            "dev": true
+        },
+        "@types/simple-peer": {
+            "version": "9.11.4",
+            "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.4.tgz",
+            "integrity": "sha512-Elje14YvM47k+XEaoyRAeUSvZN7TOLWYL233QCckUaXjT4lRESHnYs0iOK2JoosO5DnCvWu/0Vpl9qnw4KCLWw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/sizzle": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+            "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
             "dev": true
         },
         "aggregate-error": {
@@ -1609,6 +7265,28 @@
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
         },
+        "backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "braces": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -1616,6 +7294,16 @@
             "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
+            }
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
             }
         },
         "callsites": {
@@ -1698,6 +7386,12 @@
             "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
             "dev": true
         },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
+        },
         "cosmiconfig": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -1731,6 +7425,22 @@
                 "ms": "2.1.2"
             }
         },
+        "define-properties": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+            "dev": true,
+            "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "earcut": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+            "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug==",
+            "dev": true
+        },
         "eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1743,6 +7453,29 @@
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true
         },
+        "engine.io-client": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.0.3.tgz",
+            "integrity": "sha512-IH8ZhDIwiLv0d/wXVzmjfV9Y82hbJIDhCGSVUV8o1kcpDe2I6Y3bZA3ZbJy4Ls7k7IVmcy/qn4k9RKWFhUGf5w==",
+            "dev": true,
+            "requires": {
+                "@socket.io/component-emitter": "~3.0.0",
+                "debug": "~4.3.1",
+                "engine.io-parser": "~5.0.0",
+                "has-cors": "1.1.0",
+                "parseqs": "0.0.6",
+                "parseuri": "0.0.6",
+                "ws": "~8.2.3",
+                "xmlhttprequest-ssl": "~2.0.0",
+                "yeast": "0.1.2"
+            }
+        },
+        "engine.io-parser": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+            "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+            "dev": true
+        },
         "error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1752,10 +7485,64 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-abstract": {
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+            "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "function.prototype.name": "^1.1.5",
+                "get-intrinsic": "^1.1.1",
+                "get-symbol-description": "^1.0.0",
+                "has": "^1.0.3",
+                "has-property-descriptors": "^1.0.0",
+                "has-symbols": "^1.0.3",
+                "internal-slot": "^1.0.3",
+                "is-callable": "^1.2.4",
+                "is-negative-zero": "^2.0.2",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "is-string": "^1.0.7",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.12.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "regexp.prototype.flags": "^1.4.3",
+                "string.prototype.trimend": "^1.0.5",
+                "string.prototype.trimstart": "^1.0.5",
+                "unbox-primitive": "^1.0.2"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "es6-promise-polyfill": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
+            "integrity": "sha512-HHb0vydCpoclpd0ySPkRXMmBw80MRt1wM4RBJBlXkux97K7gleabZdsR0gvE1nNPM9mgOZIBTzjjXiPxf4lIqQ==",
+            "dev": true
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true
+        },
+        "eventemitter3": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
             "dev": true
         },
         "execa": {
@@ -1803,16 +7590,131 @@
                 "semver-regex": "^3.1.2"
             }
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "function.prototype.name": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+            "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.19.0",
+                "functions-have-names": "^1.2.2"
+            }
+        },
+        "functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "dev": true
+        },
+        "get-intrinsic": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+            "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.3"
+            }
+        },
         "get-stream": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true
         },
+        "get-symbol-description": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.7.7",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-bigints": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+            "dev": true
+        },
+        "has-cors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+            "integrity": "sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==",
+            "dev": true
+        },
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true
+        },
+        "has-property-descriptors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.1"
+            }
+        },
+        "has-symbols": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "dev": true
+        },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true
         },
         "human-signals": {
@@ -1855,16 +7757,76 @@
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true
         },
+        "internal-slot": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            }
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
         },
+        "is-bigint": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+            "dev": true,
+            "requires": {
+                "has-bigints": "^1.0.1"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-callable": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "dev": true
+        },
+        "is-core-module": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+            "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
         "is-fullwidth-code-point": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
             "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+            "dev": true
+        },
+        "is-negative-zero": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
             "dev": true
         },
         "is-number": {
@@ -1873,11 +7835,66 @@
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
         },
+        "is-number-object": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-regex": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-shared-array-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
         "is-stream": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
             "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
             "dev": true
+        },
+        "is-string": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-weakref": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
         },
         "isexe": {
             "version": "2.0.0",
@@ -1885,10 +7902,22 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
+        "ismobilejs": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+            "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+            "dev": true
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
         },
         "json-parse-even-better-errors": {
@@ -2015,6 +8044,30 @@
                 }
             }
         },
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                }
+            }
+        },
         "locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2098,6 +8151,12 @@
                 }
             }
         },
+        "memorystream": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+            "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+            "dev": true
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2120,17 +8179,180 @@
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
             "dev": true
         },
+        "mini-signals": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
+            "integrity": "sha512-alffqMkGCjjTSwvYMVLx+7QeJ6sTuxbXqBkP21my4iWU5+QpTQAJt3h7htA1OKm9F3BpMM0vnu72QIoiJakrLA==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
+        },
+        "npm-run-all": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+            "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "memorystream": "^0.3.1",
+                "minimatch": "^3.0.4",
+                "pidtree": "^0.3.0",
+                "read-pkg": "^3.0.0",
+                "shell-quote": "^1.6.1",
+                "string.prototype.padend": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+                    "dev": true
+                },
+                "pidtree": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+                    "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
         },
         "npm-run-path": {
             "version": "5.1.0",
@@ -2149,11 +8371,35 @@
                 }
             }
         },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true
+        },
         "object-inspect": {
             "version": "1.12.2",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
             "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
             "dev": true
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            }
         },
         "onetime": {
             "version": "6.0.0",
@@ -2218,6 +8464,24 @@
                 "lines-and-columns": "^1.1.6"
             }
         },
+        "parse-uri": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.7.tgz",
+            "integrity": "sha512-eWuZCMKNlVkXrEoANdXxbmqhu2SQO9jUMCSpdbJDObin0JxISn6e400EWsSRbr/czdKvWKkhZnMKEGUwf/Plmg==",
+            "dev": true
+        },
+        "parseqs": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+            "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+            "dev": true
+        },
+        "parseuri": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+            "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+            "dev": true
+        },
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2228,6 +8492,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
         "path-type": {
@@ -2247,6 +8517,165 @@
             "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
             "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
             "dev": true
+        },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "dev": true
+        },
+        "pixi-particles": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/pixi-particles/-/pixi-particles-4.3.1.tgz",
+            "integrity": "sha512-XSqDFgYwm/7FRCgP5I2Fc57d98qvb1ql/x4uTjdP4uXDUGgjdO8OW/2A0HVWS1CkOht/1x6dQzsM1oCJAUlaow==",
+            "dev": true,
+            "requires": {}
+        },
+        "pixi.js": {
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.11.tgz",
+            "integrity": "sha512-/9td6IHDQqG0Po5lyQ5aKDzrnEVD1SvGourI4Nqp0mvNI0Cbm74tMHLjk1V5foqGPAS9pochENr6Y3ft/2cDiQ==",
+            "dev": true,
+            "requires": {
+                "@pixi/accessibility": "5.3.11",
+                "@pixi/app": "5.3.11",
+                "@pixi/constants": "5.3.11",
+                "@pixi/core": "5.3.11",
+                "@pixi/display": "5.3.11",
+                "@pixi/extract": "5.3.11",
+                "@pixi/filter-alpha": "5.3.11",
+                "@pixi/filter-blur": "5.3.11",
+                "@pixi/filter-color-matrix": "5.3.11",
+                "@pixi/filter-displacement": "5.3.11",
+                "@pixi/filter-fxaa": "5.3.11",
+                "@pixi/filter-noise": "5.3.11",
+                "@pixi/graphics": "5.3.11",
+                "@pixi/interaction": "5.3.11",
+                "@pixi/loaders": "5.3.11",
+                "@pixi/math": "5.3.11",
+                "@pixi/mesh": "5.3.11",
+                "@pixi/mesh-extras": "5.3.11",
+                "@pixi/mixin-cache-as-bitmap": "5.3.11",
+                "@pixi/mixin-get-child-by-name": "5.3.11",
+                "@pixi/mixin-get-global-position": "5.3.11",
+                "@pixi/particles": "5.3.11",
+                "@pixi/polyfill": "5.3.11",
+                "@pixi/prepare": "5.3.11",
+                "@pixi/runner": "5.3.11",
+                "@pixi/settings": "5.3.11",
+                "@pixi/sprite": "5.3.11",
+                "@pixi/sprite-animated": "5.3.11",
+                "@pixi/sprite-tiling": "5.3.11",
+                "@pixi/spritesheet": "5.3.11",
+                "@pixi/text": "5.3.11",
+                "@pixi/text-bitmap": "5.3.11",
+                "@pixi/ticker": "5.3.11",
+                "@pixi/utils": "5.3.11"
+            },
+            "dependencies": {
+                "@pixi/constants": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+                    "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+                    "dev": true
+                },
+                "@pixi/core": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+                    "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/runner": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/ticker": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/display": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+                    "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/graphics": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.11.tgz",
+                    "integrity": "sha512-HLu53LV6mRlY0uFSIM2OrCuL7xqXzeJs5d2QfmUJfKJVVZ9sbHDS+6/N/f0tXzvkRPYhSKXvcNPsNn4HmlIE9w==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/core": "5.3.11",
+                        "@pixi/display": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/sprite": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/math": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+                    "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+                    "dev": true
+                },
+                "@pixi/runner": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+                    "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+                    "dev": true
+                },
+                "@pixi/settings": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+                    "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+                    "dev": true,
+                    "requires": {
+                        "ismobilejs": "^1.1.0"
+                    }
+                },
+                "@pixi/sprite": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+                    "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/core": "5.3.11",
+                        "@pixi/display": "5.3.11",
+                        "@pixi/math": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "@pixi/utils": "5.3.11"
+                    }
+                },
+                "@pixi/ticker": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+                    "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/settings": "5.3.11"
+                    }
+                },
+                "@pixi/utils": {
+                    "version": "5.3.11",
+                    "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+                    "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@pixi/constants": "5.3.11",
+                        "@pixi/settings": "5.3.11",
+                        "earcut": "^2.1.5",
+                        "eventemitter3": "^3.1.0",
+                        "url": "^0.11.0"
+                    }
+                }
+            }
         },
         "pkg-dir": {
             "version": "5.0.0",
@@ -2272,11 +8701,77 @@
             "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
             "dev": true
         },
+        "punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+            "dev": true
+        },
+        "read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "regexp.prototype.flags": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+            "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "functions-have-names": "^1.2.2"
+            }
+        },
+        "resolve": {
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+            "dev": true,
+            "requires": {
+                "is-core-module": "^2.9.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            }
+        },
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
+        },
+        "resource-loader": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
+            "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
+            "dev": true,
+            "requires": {
+                "mini-signals": "^1.2.0",
+                "parse-uri": "^1.0.0"
+            }
         },
         "restore-cursor": {
             "version": "3.1.0",
@@ -2320,6 +8815,12 @@
                 "tslib": "^2.1.0"
             }
         },
+        "semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
+        },
         "semver-compare": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
@@ -2346,6 +8847,23 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
+        },
+        "shell-quote": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+            "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+            "dev": true
+        },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            }
         },
         "signal-exit": {
             "version": "3.0.7",
@@ -2377,6 +8895,68 @@
                 }
             }
         },
+        "socket.io-client": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.3.2.tgz",
+            "integrity": "sha512-2B9LqSunN60yV8F7S84CCEEcgbYNfrn7ejIInZtLZ7ppWtiX8rGZAjvdCvbnC8bqo/9RlCNOUsORLyskxSFP1g==",
+            "dev": true,
+            "requires": {
+                "@socket.io/component-emitter": "~3.0.0",
+                "backo2": "~1.0.2",
+                "debug": "~4.3.2",
+                "engine.io-client": "~6.0.1",
+                "parseuri": "0.0.6",
+                "socket.io-parser": "~4.1.1"
+            }
+        },
+        "socket.io-parser": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
+            "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
+            "dev": true,
+            "requires": {
+                "@socket.io/component-emitter": "~3.0.0",
+                "debug": "~4.3.1"
+            }
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+            "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+            "dev": true
+        },
         "string-argv": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -2394,6 +8974,39 @@
                 "strip-ansi": "^7.0.1"
             }
         },
+        "string.prototype.padend": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz",
+            "integrity": "sha512-jNIIeokznm8SD/TZISQsZKYu7RJyheFNt84DUPrh482GC8RVp2MKqm2O5oBRdGxbDQoXrhhWtPIWQOiy20svUg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.19.1"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+            "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.19.5"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+            "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.19.5"
+            }
+        },
         "strip-ansi": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
@@ -2402,6 +9015,12 @@
             "requires": {
                 "ansi-regex": "^6.0.1"
             }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true
         },
         "strip-final-newline": {
             "version": "3.0.0",
@@ -2418,10 +9037,22 @@
                 "has-flag": "^4.0.0"
             }
         },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true
+        },
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tinymce": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.1.tgz",
+            "integrity": "sha512-aIsFTYiuESpoYkCgkoojpVtPwrSvYBxp4mMEGsj20CnUruLCWosywkbYHDII+j7KlQZZn3p+xK89f5gT3QyuGw==",
             "dev": true
         },
         "to-regex-range": {
@@ -2445,6 +9076,51 @@
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true
         },
+        "typescript": {
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
+            "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
+            "dev": true,
+            "optional": true
+        },
+        "unbox-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.0.3",
+                "which-boxed-primitive": "^1.0.2"
+            }
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2454,10 +9130,29 @@
                 "isexe": "^2.0.0"
             }
         },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dev": true,
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
         "which-pm-runs": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
             "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
             "dev": true
         },
         "wrap-ansi": {
@@ -2511,10 +9206,29 @@
                 }
             }
         },
+        "ws": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "dev": true,
+            "requires": {}
+        },
+        "xmlhttprequest-ssl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+            "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+            "dev": true
+        },
         "yaml": {
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "dev": true
+        },
+        "yeast": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+            "integrity": "sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==",
             "dev": true
         },
         "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "name": "ponyfinder-foundryvtt-module",
             "devDependencies": {
                 "@league-of-foundry-developers/foundry-vtt-types": "^9.269.0",
-                "@tsconfig/node16": "^1.0.3",
+                "@tsconfig/node16-strictest-esm": "^1.0.3",
                 "husky-v4": "^4.3.8",
                 "lint-staged": "^13.0.1",
                 "npm-run-all": "^4.1.5",
@@ -2254,10 +2254,10 @@
             "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
             "dev": true
         },
-        "node_modules/@tsconfig/node16": {
+        "node_modules/@tsconfig/node16-strictest-esm": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest-esm/-/node16-strictest-esm-1.0.3.tgz",
+            "integrity": "sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==",
             "dev": true
         },
         "node_modules/@types/earcut": {
@@ -7169,10 +7169,10 @@
             "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
             "dev": true
         },
-        "@tsconfig/node16": {
+        "@tsconfig/node16-strictest-esm": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest-esm/-/node16-strictest-esm-1.0.3.tgz",
+            "integrity": "sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==",
             "dev": true
         },
         "@types/earcut": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "build": "run-s build:*",
         "build:1-typescript": "tsc -b .",
         "build:2-packs": "node src/packs/scripts/build.cjs",
-        "format": "prettier --ignore-unknown --write ."
+        "format": "prettier --ignore-unknown --write .",
+        "postinstall": "patch-package"
     },
     "husky": {
         "hooks": {
@@ -25,6 +26,7 @@
         "husky-v4": "^4.3.8",
         "lint-staged": "^13.0.1",
         "npm-run-all": "^4.1.5",
+        "patch-package": "^6.4.7",
         "prettier": "^2.6.2",
         "typescript": "^4.7.4"
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@league-of-foundry-developers/foundry-vtt-types": "^9.269.0",
-        "@tsconfig/node16": "^1.0.3",
+        "@tsconfig/node16-strictest-esm": "^1.0.3",
         "husky-v4": "^4.3.8",
         "lint-staged": "^13.0.1",
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
     "name": "ponyfinder-foundryvtt-module",
     "private": true,
+    "type": "module",
     "engines": {
         "node": "16"
     },
     "scripts": {
-        "build": "node src/packs/scripts/build.cjs",
+        "build": "run-s build:*",
+        "build:1-typescript": "tsc -b .",
+        "build:2-packs": "node src/packs/scripts/build.cjs",
         "format": "prettier --ignore-unknown --write ."
     },
     "husky": {
@@ -17,8 +20,12 @@
         "*": "prettier --ignore-unknown --write"
     },
     "devDependencies": {
+        "@league-of-foundry-developers/foundry-vtt-types": "^9.269.0",
+        "@tsconfig/node16": "^1.0.3",
         "husky-v4": "^4.3.8",
         "lint-staged": "^13.0.1",
-        "prettier": "^2.6.2"
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.6.2",
+        "typescript": "^4.7.4"
     }
 }

--- a/patches/@league-of-foundry-developers+foundry-vtt-types+9.269.0.patch
+++ b/patches/@league-of-foundry-developers+foundry-vtt-types+9.269.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData.d.ts b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData.d.ts
+index 44f6ecd..23886bb 100644
+--- a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData.d.ts
++++ b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData.d.ts
+@@ -56,7 +56,7 @@ interface ItemDataBaseProperties {
+    * The system data object which is defined by the system template.json model
+    * @defaultValue template from template.json for type or `{}`
+    */
+-  data: object;
++  data: Record<string, unknown>;
+ 
+   /**
+    * A collection of ActiveEffect embedded Documents

--- a/scripts/heritage-ability-boosts.mts
+++ b/scripts/heritage-ability-boosts.mts
@@ -1,3 +1,4 @@
+import type { BaseItem } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs";
 import { name, title } from "../module.json";
 
 const ENABLE_THIS_SETTING_KEY = "enableHeritageAbilityBoosts";
@@ -17,14 +18,14 @@ Hooks.once("init", () => {
     });
 });
 
-Hooks.on("dropActorSheetData", (actor, sheet, data) => {
+Hooks.on("dropActorSheetData", (actor) => {
     try {
         if (!(game as Game).settings.get(name, ENABLE_THIS_SETTING_KEY)) {
             return true;
         }
 
-        const ancestry = (actor as any).ancestry as Item | null;
-        const heritage = (actor as any).heritage as Item | null;
+        const ancestry = (actor as any).ancestry as BaseItem | null;
+        const heritage = (actor as any).heritage as BaseItem | null;
 
         if (!ancestry || !heritage) {
             return true;
@@ -32,7 +33,7 @@ Hooks.on("dropActorSheetData", (actor, sheet, data) => {
 
         const { boosts, flaws } = heritage.data.data as Record<string, unknown>;
 
-        if (boosts) {
+        if (boosts && boosts !== (ancestry.data.data as any).boosts) {
             console.info(
                 "Found boosts from heritage to apply to ancestry:",
                 boosts
@@ -40,7 +41,7 @@ Hooks.on("dropActorSheetData", (actor, sheet, data) => {
             ancestry.data.update({ data: { boosts } });
         }
 
-        if (flaws) {
+        if (flaws && flaws !== (ancestry.data.data as any).flaws) {
             console.info(
                 "Found flaws from heritage to apply to ancestry:",
                 boosts

--- a/scripts/heritage-ability-boosts.mts
+++ b/scripts/heritage-ability-boosts.mts
@@ -1,4 +1,3 @@
-import type { BaseItem } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs";
 import { name, title } from "../module.json";
 
 const ENABLE_THIS_SETTING_KEY = "enableHeritageAbilityBoosts";
@@ -18,46 +17,109 @@ Hooks.once("init", () => {
     });
 });
 
-Hooks.on("dropActorSheetData", (actor) => {
-    try {
-        if (!(game as Game).settings.get(name, ENABLE_THIS_SETTING_KEY)) {
+Hooks.on(
+    "dropActorSheetData",
+    async (
+        actor,
+        _,
+        data: Item | { type: string; id: string; pack: string }
+    ) => {
+        try {
+            if (
+                !(game as Game).settings.get(name, ENABLE_THIS_SETTING_KEY) ||
+                data.type !== "Item"
+            ) {
+                return true;
+            }
+
+            const fullData =
+                data.pack && data.id
+                    ? ((await (game as Game).packs
+                          .get(data.pack)
+                          ?.getDocument(data.id)) as StoredDocument<Item>)
+                    : undefined;
+            if (
+                !fullData ||
+                (fullData.data.type !== "ancestry" &&
+                    fullData.data.type !== "heritage")
+            ) {
+                return true;
+            }
+
+            const ancestry =
+                fullData.data.type === "ancestry"
+                    ? fullData
+                    : (actor as Actor & { ancestry: Item | null }).ancestry;
+            const heritage =
+                fullData.data.type === "heritage"
+                    ? fullData
+                    : (actor as Actor & { heritage: Item | null }).heritage;
+            if (!ancestry || !heritage) {
+                return true;
+            }
+
+            const { boosts, flaws } = heritage.data.data as {
+                boosts?: Record<string, unknown>;
+                flaws?: Record<string, unknown>;
+            };
+            if (
+                (!boosts ||
+                    isObjectEmpty(
+                        diffObject(
+                            boosts,
+                            (ancestry.data.data as any)["boosts"]
+                        )
+                    )) &&
+                (!flaws ||
+                    isObjectEmpty(
+                        diffObject(flaws, (ancestry.data.data as any)["flaws"])
+                    ))
+            ) {
+                console.info(
+                    `${name} | Skipping applying boosts and flaws because they're already identical:`,
+                    { boosts, flaws },
+                    {
+                        boosts: (ancestry.data.data as any)["boosts"],
+                        flaws: (ancestry.data.data as any)["flaws"],
+                    }
+                );
+                return true;
+            }
+
+            console.info(
+                `${name} | Found boosts and flaws from heritage to apply to ancestry:`,
+                { boosts, flaws }
+            );
+
+            if (boosts) {
+                await actor.updateEmbeddedDocuments("Item", [
+                    { _id: ancestry.data._id, data: { boosts } },
+                ]);
+            }
+
+            if (flaws) {
+                await actor.updateEmbeddedDocuments("Item", [
+                    { _id: ancestry.data._id, data: { flaws } },
+                ]);
+            }
+
+            actor.render();
+        } catch (error) {
+            console.error(
+                `${name} | error in heritage-ability-boosts script`,
+                error
+            );
+            ui.notifications?.error(
+                `${title}: ${(game as Game).i18n.localize(
+                    `${name}.enableHeritageAbilityBoosts`
+                )} reported: ${
+                    error instanceof Error
+                        ? error.message
+                        : JSON.stringify(error)
+                }`
+            );
+        } finally {
             return true;
         }
-
-        const ancestry = (actor as any).ancestry as BaseItem | null;
-        const heritage = (actor as any).heritage as BaseItem | null;
-
-        if (!ancestry || !heritage) {
-            return true;
-        }
-
-        const { boosts, flaws } = heritage.data.data as Record<string, unknown>;
-
-        if (boosts && boosts !== (ancestry.data.data as any).boosts) {
-            console.info(
-                "Found boosts from heritage to apply to ancestry:",
-                boosts
-            );
-            ancestry.data.update({ data: { boosts } });
-        }
-
-        if (flaws && flaws !== (ancestry.data.data as any).flaws) {
-            console.info(
-                "Found flaws from heritage to apply to ancestry:",
-                boosts
-            );
-            ancestry.data.update({ data: { flaws } });
-        }
-    } catch (error) {
-        console.error(name, "heritage-ability-boosts", error);
-        ui.notifications?.error(
-            `${title}: ${(game as Game).i18n.localize(
-                `${name}.enableHeritageAbilityBoosts`
-            )} reported: ${
-                error instanceof Error ? error.message : JSON.stringify(error)
-            }`
-        );
-    } finally {
-        return true;
     }
-});
+);

--- a/scripts/heritage-ability-boosts.mts
+++ b/scripts/heritage-ability-boosts.mts
@@ -1,0 +1,62 @@
+import { name, title } from "../module.json";
+
+const ENABLE_THIS_SETTING_KEY = "enableHeritageAbilityBoosts";
+
+Hooks.once("init", () => {
+    (game as Game).settings.register(name, ENABLE_THIS_SETTING_KEY, {
+        name: (game as Game).i18n.localize(
+            `${name}.enableHeritageAbilityBoosts`
+        ),
+        hint: (game as Game).i18n.localize(
+            `${name}.enableHeritageAbilityBoostsHint`
+        ),
+        scope: "world",
+        config: true,
+        type: Boolean,
+        default: true,
+    });
+});
+
+Hooks.on("dropActorSheetData", (actor, sheet, data) => {
+    try {
+        if (!(game as Game).settings.get(name, ENABLE_THIS_SETTING_KEY)) {
+            return true;
+        }
+
+        const ancestry = (actor as any).ancestry as Item | null;
+        const heritage = (actor as any).heritage as Item | null;
+
+        if (!ancestry || !heritage) {
+            return true;
+        }
+
+        const { boosts, flaws } = heritage.data.data as Record<string, unknown>;
+
+        if (boosts) {
+            console.info(
+                "Found boosts from heritage to apply to ancestry:",
+                boosts
+            );
+            ancestry.data.update({ data: { boosts } });
+        }
+
+        if (flaws) {
+            console.info(
+                "Found flaws from heritage to apply to ancestry:",
+                boosts
+            );
+            ancestry.data.update({ data: { flaws } });
+        }
+    } catch (error) {
+        console.error(name, "heritage-ability-boosts", error);
+        ui.notifications?.error(
+            `${title}: ${(game as Game).i18n.localize(
+                `${name}.enableHeritageAbilityBoosts`
+            )} reported: ${
+                error instanceof Error ? error.message : JSON.stringify(error)
+            }`
+        );
+    } finally {
+        return true;
+    }
+});

--- a/scripts/heritage-ability-boosts.mts
+++ b/scripts/heritage-ability-boosts.mts
@@ -1,14 +1,14 @@
-import { name, title } from "../module.json";
-
+const MODULE_NAME = "ponyfinder-foundryvtt-module";
+const MODULE_TITLE = "Ponyfinder FoundryVTT Content";
 const ENABLE_THIS_SETTING_KEY = "enableHeritageAbilityBoosts";
 
 Hooks.once("init", () => {
-    (game as Game).settings.register(name, ENABLE_THIS_SETTING_KEY, {
+    (game as Game).settings.register(MODULE_NAME, ENABLE_THIS_SETTING_KEY, {
         name: (game as Game).i18n.localize(
-            `${name}.enableHeritageAbilityBoosts`
+            `${MODULE_NAME}.enableHeritageAbilityBoosts`
         ),
         hint: (game as Game).i18n.localize(
-            `${name}.enableHeritageAbilityBoostsHint`
+            `${MODULE_NAME}.enableHeritageAbilityBoostsHint`
         ),
         scope: "world",
         config: true,
@@ -26,7 +26,10 @@ Hooks.on(
     ) => {
         try {
             if (
-                !(game as Game).settings.get(name, ENABLE_THIS_SETTING_KEY) ||
+                !(game as Game).settings.get(
+                    MODULE_NAME,
+                    ENABLE_THIS_SETTING_KEY
+                ) ||
                 data.type !== "Item"
             ) {
                 return true;
@@ -76,7 +79,7 @@ Hooks.on(
                     ))
             ) {
                 console.info(
-                    `${name} | Skipping applying boosts and flaws because they're already identical:`,
+                    `${MODULE_NAME} | Skipping applying boosts and flaws because they're already identical:`,
                     { boosts, flaws },
                     {
                         boosts: (ancestry.data.data as any)["boosts"],
@@ -87,7 +90,7 @@ Hooks.on(
             }
 
             console.info(
-                `${name} | Found boosts and flaws from heritage to apply to ancestry:`,
+                `${MODULE_NAME} | Found boosts and flaws from heritage to apply to ancestry:`,
                 { boosts, flaws }
             );
 
@@ -106,12 +109,12 @@ Hooks.on(
             actor.render();
         } catch (error) {
             console.error(
-                `${name} | error in heritage-ability-boosts script`,
+                `${MODULE_NAME} | error in heritage-ability-boosts script`,
                 error
             );
             ui.notifications?.error(
-                `${title}: ${(game as Game).i18n.localize(
-                    `${name}.enableHeritageAbilityBoosts`
+                `${MODULE_TITLE}: ${(game as Game).i18n.localize(
+                    `${MODULE_NAME}.enableHeritageAbilityBoosts`
                 )} reported: ${
                     error instanceof Error
                         ? error.message

--- a/src/packs/data/ponyfinder-ancestries.db/griffon.json
+++ b/src/packs/data/ponyfinder-ancestries.db/griffon.json
@@ -13,6 +13,14 @@
             "rarity": "common",
             "custom": ""
         },
+        "boosts": {
+            "0": { "value": ["str"] },
+            "1": { "value": ["wis"] },
+            "2": { "value": ["str", "dex", "con", "int", "wis", "cha"] }
+        },
+        "flaws": {
+            "0": { "value": ["cha"] }
+        },
         "rules": [
             {
                 "key": "ChoiceSet",

--- a/src/packs/data/ponyfinder-ancestries.db/ponykind.json
+++ b/src/packs/data/ponyfinder-ancestries.db/ponykind.json
@@ -13,6 +13,14 @@
             "rarity": "common",
             "custom": ""
         },
+        "boosts": {
+            "0": { "value": ["str", "dex", "con", "int", "wis", "cha"] },
+            "1": { "value": [] },
+            "2": { "value": ["str", "dex", "con", "int", "wis", "cha"] }
+        },
+        "flaws": {
+            "0": { "value": [] }
+        },
         "rules": [],
         "hp": 8,
         "size": "med",

--- a/src/packs/data/ponyfinder-heritages.db/pride-aspect.json
+++ b/src/packs/data/ponyfinder-heritages.db/pride-aspect.json
@@ -15,9 +15,7 @@
             "2": { "value": ["str", "dex", "con", "int", "wis", "cha"] }
         },
         "flaws": {
-            "0": {
-                "value": ["wis"]
-            }
+            "0": { "value": ["wis"] }
         },
         "rules": [
             {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,8 @@
 {
-    "extends": "@tsconfig/node16/tsconfig.json",
+    "extends": "@tsconfig/node16-strictest-esm",
     "compilerOptions": {
-        "module": "node16",
         "outDir": "./dist",
         "resolveJsonModule": true,
-        "strict": true,
         "types": ["@league-of-foundry-developers/foundry-vtt-types"]
     },
     "include": ["scripts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "@tsconfig/node16/tsconfig.json",
+    "compilerOptions": {
+        "module": "node16",
+        "outDir": "./dist",
+        "resolveJsonModule": true,
+        "strict": true,
+        "types": ["@league-of-foundry-developers/foundry-vtt-types"]
+    },
+    "include": ["scripts"],
+    "exclude": ["dist", "packs"]
+}


### PR DESCRIPTION
From my testing this should now be working without hiccups, but I would appreciate any poking and prodding you would care to contribute.

Basically, this hooks on `dropActorSheetData`, and whenever the dropped item is a heritage, checks if it has boosts/flaws on its data, and if it does, updates the actor's embedded ancestry to have those (pulling data from the compendium if necessary), overwriting whatever boosts/flaws the ancestry had initially. Since it's only triggering on dropping something on a sheet (rather than updates in general) it should be a minimal performance hit.

This adds Typescript to the build to get some of the benefit of local typing, but it's all already set up, so just running `npm install` / `npm run build` should be all that's needed to get the final script.